### PR TITLE
IGNITE-16731 Update ignite-extensions: dependency zookeeper&curator

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -72,7 +72,7 @@
         <commons.lang.version>2.6</commons.lang.version>
         <commons.io.version>2.6</commons.io.version>
         <cron4j.version>2.2.5</cron4j.version>
-        <curator.version>4.2.0</curator.version>
+        <curator.version>5.2.1</curator.version>
         <easymock.version>3.4</easymock.version>
         <ezmorph.bundle.version>1.0.6_1</ezmorph.bundle.version>
         <ezmorph.version>1.0.6</ezmorph.version>
@@ -149,7 +149,7 @@
         <yammer.metrics.core.version>2.2.0</yammer.metrics.core.version>
         <yardstick.version>0.8.3</yardstick.version>
         <zkclient.version>0.5</zkclient.version>
-        <zookeeper.version>3.5.5</zookeeper.version>
+        <zookeeper.version>3.8.0</zookeeper.version>
         <zstd.version>1.3.7-2</zstd.version>
         <opencensus.version>0.22.0</opencensus.version>
         <surefire.version>3.0.0-M4</surefire.version>


### PR DESCRIPTION
Update Ignite dependency: Zookeeper 3.5.5 to 3.8.0 and curator 4.2.0 to 5.2.1
