### PR TITLE
IGNITE-19899 Use autoconfigure scheme for SpringBoot 2.7+

### DIFF
--- a/modules/spring-boot-autoconfigure-ext/spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/modules/spring-boot-autoconfigure-ext/spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.ignite.springframework.boot.autoconfigure.IgniteAutoConfiguration
+org.apache.ignite.springframework.boot.autoconfigure.IgniteRepositoryAutoConfiguration

--- a/modules/spring-boot-thin-client-autoconfigure-ext/spring-boot-thin-client-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/modules/spring-boot-thin-client-autoconfigure-ext/spring-boot-thin-client-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -15,3 +15,4 @@
 
 org.apache.ignite.springframework.boot.autoconfigure.IgniteClientAutoConfiguration
 org.apache.ignite.springframework.boot.autoconfigure.IgniteClientRepositoryAutoConfiguration
+

--- a/modules/spring-boot-thin-client-autoconfigure-ext/spring-boot-thin-client-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/modules/spring-boot-thin-client-autoconfigure-ext/spring-boot-thin-client-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.ignite.springframework.boot.autoconfigure.IgniteClientAutoConfiguration
+org.apache.ignite.springframework.boot.autoconfigure.IgniteClientRepositoryAutoConfiguration


### PR DESCRIPTION
SpringBoot 2.7 uses a different way of finding extensions. This leaves the old method intact but allows the autoconfigurer to work with versions 2.7 and 3.x.