### PR TITLE
IGNITE-20139 Random forest stopping criteria check fixed. Gain calculation implemented.

### DIFF
--- a/modules/ml-ext/ml/src/main/java/org/apache/ignite/ml/tree/randomforest/RandomForestTrainer.java
+++ b/modules/ml-ext/ml/src/main/java/org/apache/ignite/ml/tree/randomforest/RandomForestTrainer.java
@@ -274,7 +274,7 @@ public abstract class RandomForestTrainer<L, S extends ImpurityComputer<Bootstra
             if (bestSplit.isPresent())
                 bestSplit.get().createLeaf(cornerNode);
             else {
-                cornerNode.setImpurity(Double.NEGATIVE_INFINITY);
+                cornerNode.setImpurity(0.0);
                 cornerNode.toLeaf(0.0);
             }
         }
@@ -383,8 +383,8 @@ public abstract class RandomForestTrainer<L, S extends ImpurityComputer<Bootstra
      * @return true if split is needed.
      */
     boolean needSplit(TreeNode parentNode, Optional<NodeSplit> split) {
-        return split.isPresent() && parentNode.getImpurity() - split.get().getImpurity() > minImpurityDelta &&
-            parentNode.getDepth() < (maxDepth + 1);
+        return split.isPresent() && split.get().getGain() > minImpurityDelta &&
+                parentNode.getDepth() < (maxDepth + 1);
     }
 
     /**

--- a/modules/ml-ext/ml/src/main/java/org/apache/ignite/ml/tree/randomforest/data/NodeSplit.java
+++ b/modules/ml-ext/ml/src/main/java/org/apache/ignite/ml/tree/randomforest/data/NodeSplit.java
@@ -36,6 +36,9 @@ public class NodeSplit implements Serializable {
     /** Impurity at this split point. */
     private double impurity;
 
+    /** Gain at this split point. */
+    private double gain;
+
     /** */
     public NodeSplit() {
     }
@@ -45,11 +48,13 @@ public class NodeSplit implements Serializable {
      *
      * @param featureId Feature id.
      * @param val Feature split value.
+     * @param gain Gain value.
      * @param impurity Impurity value.
      */
-    public NodeSplit(int featureId, double val, double impurity) {
+    public NodeSplit(int featureId, double val, double gain, double impurity) {
         this.featureId = featureId;
         this.val = val;
+        this.gain = gain;
         this.impurity = impurity;
     }
 
@@ -78,6 +83,11 @@ public class NodeSplit implements Serializable {
     /** */
     public double getImpurity() {
         return impurity;
+    }
+
+    /** */
+    public double getGain() {
+        return gain;
     }
 
     /** */

--- a/modules/ml-ext/ml/src/main/java/org/apache/ignite/ml/tree/randomforest/data/impurity/ImpurityHistogram.java
+++ b/modules/ml-ext/ml/src/main/java/org/apache/ignite/ml/tree/randomforest/data/impurity/ImpurityHistogram.java
@@ -51,14 +51,15 @@ public abstract class ImpurityHistogram implements Serializable {
      *
      * @param bestBucketId Best bucket id.
      * @param bestSplitVal Best split value.
-     * @param bestImpurity Best impurity.
+     * @param bestGain Best gain.
+     * @param impurity Node's impurity.
      * @return Best split value.
      */
-    protected Optional<NodeSplit> checkAndReturnSplitValue(int bestBucketId, double bestSplitVal, double bestImpurity) {
+    protected Optional<NodeSplit> checkAndReturnSplitValue(int bestBucketId, double bestSplitVal, double bestGain, double impurity) {
         if (isLastBucket(bestBucketId))
             return Optional.empty();
         else
-            return Optional.of(new NodeSplit(featureId, bestSplitVal, bestImpurity));
+            return Optional.of(new NodeSplit(featureId, bestSplitVal, bestGain, impurity));
     }
 
     /**

--- a/modules/ml-ext/ml/src/main/java/org/apache/ignite/ml/tree/randomforest/data/impurity/ImpurityHistogramsComputer.java
+++ b/modules/ml-ext/ml/src/main/java/org/apache/ignite/ml/tree/randomforest/data/impurity/ImpurityHistogramsComputer.java
@@ -204,8 +204,8 @@ public abstract class ImpurityHistogramsComputer<S extends ImpurityComputer<Boot
          */
         public Optional<NodeSplit> findBestSplit() {
             return perFeatureStatistics.values().stream()
-                .flatMap(x -> x.findBestSplit().map(Stream::of).orElse(Stream.empty()))
-                .min(Comparator.comparingDouble(NodeSplit::getImpurity));
+                    .flatMap(x -> x.findBestSplit().map(Stream::of).orElse(Stream.empty()))
+                    .max(Comparator.comparingDouble(NodeSplit::getGain));
         }
     }
 }

--- a/modules/ml-ext/ml/src/main/java/org/apache/ignite/ml/tree/randomforest/data/impurity/MSEHistogram.java
+++ b/modules/ml-ext/ml/src/main/java/org/apache/ignite/ml/tree/randomforest/data/impurity/MSEHistogram.java
@@ -97,9 +97,9 @@ public class MSEHistogram extends ImpurityHistogram implements ImpurityComputer<
 
     /** {@inheritDoc} */
     @Override public Optional<NodeSplit> findBestSplit() {
-        double bestImpurity = Double.POSITIVE_INFINITY;
         double bestSplitVal = Double.NEGATIVE_INFINITY;
         int bestBucketId = -1;
+        double bestGain = 0;
 
         //counter corresponds to number of samples
         //ys corresponds to sumOfLabels
@@ -111,6 +111,8 @@ public class MSEHistogram extends ImpurityHistogram implements ImpurityComputer<
         double cntrMax = cntrDistrib.lastEntry().getValue();
         double ysMax = ysDistrib.lastEntry().getValue();
         double y2sMax = y2sDistrib.lastEntry().getValue();
+
+        double nodeImpurity = impurity(cntrMax, ysMax, y2sMax);
 
         double lastLeftCntrVal = 0.0;
         double lastLeftYVal = 0.0;
@@ -127,21 +129,23 @@ public class MSEHistogram extends ImpurityHistogram implements ImpurityComputer<
             double rightY = ysMax - leftY;
             double rightY2 = y2sMax - leftY2;
 
-            double impurity = 0.0;
+            double childrenImpurity = 0.0;
 
             if (leftCnt > 0)
-                impurity += impurity(leftCnt, leftY, leftY2);
+                childrenImpurity += impurity(leftCnt, leftY, leftY2);
             if (rightCnt > 0)
-                impurity += impurity(rightCnt, rightY, rightY2);
+                childrenImpurity += impurity(rightCnt, rightY, rightY2);
 
-            if (impurity < bestImpurity) {
-                bestImpurity = impurity;
+            double gain = nodeImpurity - childrenImpurity;
+
+            if (gain > bestGain) {
+                bestGain = gain;
                 bestSplitVal = bucketMeta.bucketIdToValue(bucketId);
                 bestBucketId = bucketId;
             }
         }
 
-        return checkAndReturnSplitValue(bestBucketId, bestSplitVal, bestImpurity);
+        return checkAndReturnSplitValue(bestBucketId, bestSplitVal, bestGain, nodeImpurity);
     }
 
     /**

--- a/modules/ml-ext/ml/src/test/java/org/apache/ignite/ml/tree/randomforest/RandomForestClassifierTrainerTest.java
+++ b/modules/ml-ext/ml/src/test/java/org/apache/ignite/ml/tree/randomforest/RandomForestClassifierTrainerTest.java
@@ -19,9 +19,13 @@ package org.apache.ignite.ml.tree.randomforest;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Random;
+import org.apache.ignite.ml.IgniteModel;
 import org.apache.ignite.ml.TestUtils;
 import org.apache.ignite.ml.common.TrainerTest;
+import org.apache.ignite.ml.composition.ModelsComposition;
 import org.apache.ignite.ml.composition.predictionsaggregator.OnMajorityPredictionsAggregator;
 import org.apache.ignite.ml.dataset.feature.FeatureMeta;
 import org.apache.ignite.ml.dataset.feature.extractor.impl.LabeledDummyVectorizer;
@@ -29,9 +33,15 @@ import org.apache.ignite.ml.math.primitives.vector.Vector;
 import org.apache.ignite.ml.math.primitives.vector.VectorUtils;
 import org.apache.ignite.ml.structures.LabeledVector;
 import org.apache.ignite.ml.trainers.DatasetTrainer;
+import org.apache.ignite.ml.tree.randomforest.data.RandomForestTreeModel;
+import org.apache.ignite.ml.tree.randomforest.data.TreeNode;
+import org.apache.ignite.testframework.GridTestUtils;
 import org.junit.Test;
 
+import static org.apache.ignite.ml.tree.randomforest.data.FeaturesCountSelectionStrategies.SQRT;
+import static org.apache.ignite.ml.tree.randomforest.data.TreeNode.Type.LEAF;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -96,5 +106,81 @@ public class RandomForestClassifierTrainerTest extends TrainerTest {
         Vector v = VectorUtils.of(5, 0.5, 0.05, 0.005);
         assertEquals(originalMdl.predict(v), updatedOnSameDS.predict(v), 0.01);
         assertEquals(originalMdl.predict(v), updatedOnEmptyDS.predict(v), 0.01);
+    }
+
+    /**
+     * Test checks whether the tree has nodes duplication.
+     */
+    @Test
+    public void testDuplicateNodes() {
+        int sampleSize = 500;
+        Random rnd = new Random(1);
+        Map<Integer, LabeledVector<Double>> sample = new HashMap<>();
+        for (int i = 0; i < sampleSize; i++) {
+            sample.put(i, VectorUtils.of(rnd.nextDouble(), rnd.nextDouble(), rnd.nextDouble(), rnd.nextDouble())
+                    .labeled((double) i % 2));
+        }
+
+        ArrayList<FeatureMeta> meta = new ArrayList<>();
+        for (int i = 0; i < 4; i++)
+            meta.add(new FeatureMeta("", i, false));
+        DatasetTrainer<RandomForestModel, Double> trainer = new RandomForestClassifierTrainer(meta)
+                .withAmountOfTrees(1)
+                .withMaxDepth(10)
+                .withFeaturesCountSelectionStrgy(SQRT)
+                .withSeed(777)
+                .withEnvironmentBuilder(TestUtils.testEnvBuilder());
+
+        ModelsComposition mdl = trainer.fit(sample, parts, new LabeledDummyVectorizer<>());
+
+        List<IgniteModel<Vector, Double>> models = mdl.getModels();
+
+        assertEquals(1, mdl.getModels().size());
+
+        RandomForestTreeModel tree = (RandomForestTreeModel) models.get(0);
+
+        TreeNode repeatingNode = findDuplicatedNode(tree.getRootNode());
+
+        assertNull(repeatingNode);
+    }
+
+    /**
+     * Go through the tree and find a node branch that has repeating feature + value.
+     */
+    private static TreeNode findDuplicatedNode(TreeNode node) {
+        if (node.getType() == LEAF) {
+            return null;
+        }
+
+        TreeNode left = node.getLeft();
+        if (getFeatureId(node) == getFeatureId(left) && getVal(node) == getVal(left)) {
+            return left;
+        }
+
+        TreeNode inLeftBranch = findDuplicatedNode(left);
+        if (inLeftBranch != null) {
+            return inLeftBranch;
+        }
+
+        TreeNode right = node.getRight();
+        if (getFeatureId(node) == getFeatureId(right) && getVal(node) == getVal(right)) {
+            return right;
+        }
+
+        return findDuplicatedNode(right);
+    }
+
+    /**
+     * Get node's value
+     */
+    private static double getVal(TreeNode node) {
+        return GridTestUtils.getFieldValue(node, TreeNode.class, "val");
+    }
+
+    /**
+     * Get node's feature id
+     */
+    private static int getFeatureId(TreeNode node) {
+        return GridTestUtils.getFieldValue(node, TreeNode.class, "featureId");
     }
 }

--- a/modules/ml-ext/ml/src/test/java/org/apache/ignite/ml/tree/randomforest/RandomForestTest.java
+++ b/modules/ml-ext/ml/src/test/java/org/apache/ignite/ml/tree/randomforest/RandomForestTest.java
@@ -37,7 +37,7 @@ public class RandomForestTest {
     private final int cntOfTrees = 10;
 
     /** Min imp delta. */
-    private final double minImpDelta = 1.0;
+    private final double minImpDelta = 0.1;
 
     /** Max depth. */
     private final int maxDepth = 1;
@@ -66,13 +66,13 @@ public class RandomForestTest {
     @Test
     public void testNeedSplit() {
         TreeNode node = new TreeNode(1, 1);
-        node.setImpurity(1000);
-        assertTrue(rf.needSplit(node, Optional.of(new NodeSplit(0, 0, node.getImpurity() - minImpDelta * 1.01))));
-        assertFalse(rf.needSplit(node, Optional.of(new NodeSplit(0, 0, node.getImpurity() - minImpDelta * 0.5))));
-        assertFalse(rf.needSplit(node, Optional.of(new NodeSplit(0, 0, node.getImpurity()))));
+        node.setImpurity(1.0);
+        assertTrue(rf.needSplit(node, Optional.of(new NodeSplit(0, 0, minImpDelta * 1.01, node.getImpurity()))));
+        assertFalse(rf.needSplit(node, Optional.of(new NodeSplit(0, 0, minImpDelta * 0.5, node.getImpurity()))));
+        assertFalse(rf.needSplit(node, Optional.of(new NodeSplit(0, 0, 0, node.getImpurity()))));
 
         TreeNode child = node.toConditional(0, 0).get(0);
-        child.setImpurity(1000);
-        assertFalse(rf.needSplit(child, Optional.of(new NodeSplit(0, 0, child.getImpurity() - minImpDelta * 1.01))));
+        child.setImpurity(1.0);
+        assertFalse(rf.needSplit(child, Optional.of(new NodeSplit(0, 0, child.getImpurity(), minImpDelta * 1.01))));
     }
 }


### PR DESCRIPTION
The issue happens when one “pure“ node (with impurity<sup>*</sup> = 0) is presented in the tree. We calculate an impurity only for children nodes and not for the current node, as well as do not check whether the node is “pure“ and contains just one label, due to that, the “bestSplit” calculation is executed for the already “pure“ node, which decides that all items should be moved to the left child node and no items to the right (leaf node), which gives 2 “pure“ children nodes. Since we don’t calculate impurity for the current (parent) node the `parentNode.getImpurity() - split.get().getImpurity() > minImpurityDelta` check is always true, and we continue to split the already “pure“ node until the max tree depth is reached.
The following changes were made to resolve the issue:

1. Gain<sup>**</sup> calculation and check for the split were added.
2. Node’s impurity check is added, once the impurity becomes 0 it means that the node is “pure” and we don’t need to calculate a split for it.
3. Gini impurity calculation was changed to `(1 - sum(p^2))` to get the correct values in the range from 0 to 0.5 as required for the Gini index.

<sup>*</sup> Impurity - is a value from 0 to 0.5, which shows whether the node is “pure“ (impurity = 0) having just 1 label or “impure” with impurity=0.5, which is the worst scenario where the label ratio is 1:1.
<sup>**</sup> Gain - is a difference between the parent node’s impurity and weighted children nodes' impurity. The split which provides the maximum gain value is considered the best. See https://www.learndatasci.com/glossary/gini-impurity/