### PR TITLE
IGNITE-22381 Fix java8 and java11 compilation

### DIFF
--- a/modules/gatling-ext/examples/pom.xml
+++ b/modules/gatling-ext/examples/pom.xml
@@ -30,6 +30,16 @@
 
     <artifactId>ignite-gatling-plugin-examples</artifactId>
 
+    <properties>
+        <!--
+            Workaround to skip gatling maven plugin execution on test phase if any of -DskipTests
+            or -Dmaven.test.skip=true JVM options are set.
+        -->
+        <maven.test.skip>false</maven.test.skip>
+        <skipTests>${maven.test.skip}</skipTests>
+        <skipGatlingMavenPlugin>${skipTests}</skipGatlingMavenPlugin>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -66,7 +76,7 @@
                 <groupId>io.gatling</groupId>
                 <artifactId>gatling-maven-plugin</artifactId>
                 <configuration>
-                    <skip>false</skip>
+                    <skip>${skipGatlingMavenPlugin}</skip>
                     <runMultipleSimulations>true</runMultipleSimulations>
                 </configuration>
                 <executions>

--- a/parent-internal/pom.xml
+++ b/parent-internal/pom.xml
@@ -194,19 +194,14 @@
             </build>
         </profile>
         <profile>
-            <id>java-9+</id>
+            <id>java-11+</id>
             <activation>
-                <jdk>[9,)</jdk>
+                <jdk>[11,)</jdk>
             </activation>
             <properties>
-                <maven.compiler.release>8</maven.compiler.release>
+                <maven.compiler.source>1.8</maven.compiler.source>
+                <maven.compiler.target>11</maven.compiler.target>
             </properties>
-        </profile>
-        <profile>
-            <id>java-15+</id>
-            <activation>
-                <jdk>[15,)</jdk>
-            </activation>
             <build>
                 <plugins>
                     <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,6 @@
         <module>modules/osgi-ext</module>
         <module>modules/ssh-ext</module>
         <module>modules/ml-ext</module>
-        <module>modules/gatling-ext</module>
     </modules>
 
     <profiles>
@@ -68,6 +67,15 @@
             <id>use-ignite-src</id>
             <modules>
                 <module>../ignite</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>java-11+</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <modules>
+                <module>modules/gatling-ext</module>
             </modules>
         </profile>
         <profile>


### PR DESCRIPTION
- Moved `gatling-ext` module under `java-11+` profile (some dependencies of this module compiled with java-11 and can't be recognized by java-8).
- For `java-11+` profile target compiler version is set to 11 (the same we have for the parent `ignite` project, even if we try to compile with 1.8 target, compiled classes still can't be used by java-8, but `target=1.8` or `release=1.8` brokes usage of `add-opens`).
- Gatling maven plugin execution is disabled when `-DskipTest` or `-Dmaven.test.skip=true` parameters are passed to maven (currently, this plugin always executed on test phase, even if we disable tests explicitely).
- Options `--add-opens` also added to `java-11+` (They are not mandatory by java-11, but they remove warnings about reflection usage).