### PR TITLE
IGNITE-22536 CDC metrics for rejected entries by conflict resolver

### DIFF
--- a/docs/_docs/cdc/change-data-capture-extensions.adoc
+++ b/docs/_docs/cdc/change-data-capture-extensions.adoc
@@ -173,8 +173,9 @@ Conflict resolution field should contain user provided monotonically increasing 
 . If `conflictResolveField` if provided then field values comparison used to determine order.
 . Conflict resolution failed. Update will be ignored.
 
-=== Metrics
-Metrics are registered for each node configured with `CacheVersionConflictResolverPluginProvider`. With that provider the corresponding metrics MBean is registered under `org.apache.ignite-instance-name.conflict-resolver`.
+=== Conflict Resolver Metrics
+
+The Ignite's built-in `CacheVersionConflictResolverPluginProvider` provides with usefull metrics.
 
 [cols="35%,65%",opts="header"]
 |===
@@ -182,6 +183,8 @@ Metrics are registered for each node configured with `CacheVersionConflictResolv
 | `AcceptedCount` | Counter of accepted entries.
 | `RejectedCount` | Counter of rejected entries.
 |===
+
+These metrics are registered under `conflict-resolver` registry for each node configured with this plugin.
 
 === Configuration example
 Configuration is done via Ignite node plugin:

--- a/docs/_docs/cdc/change-data-capture-extensions.adoc
+++ b/docs/_docs/cdc/change-data-capture-extensions.adoc
@@ -173,6 +173,16 @@ Conflict resolution field should contain user provided monotonically increasing 
 . If `conflictResolveField` if provided then field values comparison used to determine order.
 . Conflict resolution failed. Update will be ignored.
 
+=== Metrics
+Metrics are registered for each node configured with `CacheVersionConflictResolverPluginProvider`.
+
+[cols="35%,65%",opts="header"]
+|===
+|Name |Description
+| `newSelectedCount` | Count of new version used.
+| `oldSelectedCount` | Count of old version used.
+|===
+
 === Configuration example
 Configuration is done via Ignite node plugin:
 

--- a/docs/_docs/cdc/change-data-capture-extensions.adoc
+++ b/docs/_docs/cdc/change-data-capture-extensions.adoc
@@ -175,13 +175,13 @@ Conflict resolution field should contain user provided monotonically increasing 
 
 === Conflict Resolver Metrics
 
-The Ignite's built-in `CacheVersionConflictResolverPluginProvider` provides with usefull metrics.
+The Ignite's built-in `CacheVersionConflictResolverPluginProvider` provides the following metrics:
 
 [cols="35%,65%",opts="header"]
 |===
 |Name |Description
-| `AcceptedCount` | Counter of accepted entries.
-| `RejectedCount` | Counter of rejected entries.
+| `AcceptedCount` | Count of accepted entries.
+| `RejectedCount` | Count of rejected entries.
 |===
 
 These metrics are registered under `conflict-resolver` registry for each node configured with this plugin.

--- a/docs/_docs/cdc/change-data-capture-extensions.adoc
+++ b/docs/_docs/cdc/change-data-capture-extensions.adoc
@@ -174,13 +174,13 @@ Conflict resolution field should contain user provided monotonically increasing 
 . Conflict resolution failed. Update will be ignored.
 
 === Metrics
-Metrics are registered for each node configured with `CacheVersionConflictResolverPluginProvider`.
+Metrics are registered for each node configured with `CacheVersionConflictResolverPluginProvider`. With that provider the corresponding metrics MBean is registered under `org.apache.ignite-instance-name.conflict-resolver`.
 
 [cols="35%,65%",opts="header"]
 |===
 |Name |Description
-| `newSelectedCount` | Count of new version used.
-| `oldSelectedCount` | Count of old version used.
+| `AcceptedCount` | Counter of accepted entries.
+| `RejectedCount` | Counter of rejected entries.
 |===
 
 === Configuration example

--- a/modules/cdc-ext/src/main/java/org/apache/ignite/cdc/conflictresolve/CacheConflictResolutionManagerImpl.java
+++ b/modules/cdc-ext/src/main/java/org/apache/ignite/cdc/conflictresolve/CacheConflictResolutionManagerImpl.java
@@ -31,6 +31,9 @@ import org.apache.ignite.lang.IgniteFuture;
  * @see CacheVersionConflictResolver
  */
 public class CacheConflictResolutionManagerImpl<K, V> implements CacheConflictResolutionManager<K, V> {
+    /** */
+    public static final String CONFLICT_RESOLVER_METRICS_REGISTRY_NAME = "conflict-resolver";
+
     /** Logger. */
     private IgniteLogger log;
 
@@ -55,9 +58,6 @@ public class CacheConflictResolutionManagerImpl<K, V> implements CacheConflictRe
     /** Grid cache context. */
     private GridCacheContext<K, V> cctx;
 
-    /** Conflict Resolver metric registry. */
-    private MetricRegistryImpl mreg;
-
     /**
      * @param conflictResolveField Field to resolve conflicts.
      * @param clusterId Cluster id.
@@ -75,6 +75,8 @@ public class CacheConflictResolutionManagerImpl<K, V> implements CacheConflictRe
     /** {@inheritDoc} */
     @Override public CacheVersionConflictResolver conflictResolver() {
         CacheVersionConflictResolver rslvr;
+
+        MetricRegistryImpl mreg = cctx.grid().context().metric().registry(CONFLICT_RESOLVER_METRICS_REGISTRY_NAME);
 
         if (resolver != null)
             rslvr = resolver;
@@ -105,8 +107,6 @@ public class CacheConflictResolutionManagerImpl<K, V> implements CacheConflictRe
         this.cctx = cctx;
         this.log = cctx.logger(CacheConflictResolutionManagerImpl.class);
         this.conflictResolverLog = cctx.logger(CacheVersionConflictResolverImpl.class);
-
-        mreg = cctx.grid().context().metric().registry("conflictResolver");
     }
 
     /** {@inheritDoc} */

--- a/modules/cdc-ext/src/main/java/org/apache/ignite/cdc/conflictresolve/CacheConflictResolutionManagerImpl.java
+++ b/modules/cdc-ext/src/main/java/org/apache/ignite/cdc/conflictresolve/CacheConflictResolutionManagerImpl.java
@@ -21,6 +21,7 @@ import org.apache.ignite.IgniteLogger;
 import org.apache.ignite.internal.processors.cache.CacheConflictResolutionManager;
 import org.apache.ignite.internal.processors.cache.GridCacheContext;
 import org.apache.ignite.internal.processors.cache.version.CacheVersionConflictResolver;
+import org.apache.ignite.internal.processors.metric.MetricRegistryImpl;
 import org.apache.ignite.lang.IgniteFuture;
 
 /**
@@ -54,6 +55,9 @@ public class CacheConflictResolutionManagerImpl<K, V> implements CacheConflictRe
     /** Grid cache context. */
     private GridCacheContext<K, V> cctx;
 
+    /** Conflict Resolver metric registry. */
+    private MetricRegistryImpl mreg;
+
     /**
      * @param conflictResolveField Field to resolve conflicts.
      * @param clusterId Cluster id.
@@ -78,14 +82,16 @@ public class CacheConflictResolutionManagerImpl<K, V> implements CacheConflictRe
             rslvr = new DebugCacheVersionConflictResolverImpl(
                 clusterId,
                 conflictResolveField,
-                conflictResolverLog
+                conflictResolverLog,
+                mreg
             );
         }
         else {
             rslvr = new CacheVersionConflictResolverImpl(
                 clusterId,
                 conflictResolveField,
-                conflictResolverLog
+                conflictResolverLog,
+                mreg
             );
         }
 
@@ -99,6 +105,8 @@ public class CacheConflictResolutionManagerImpl<K, V> implements CacheConflictRe
         this.cctx = cctx;
         this.log = cctx.logger(CacheConflictResolutionManagerImpl.class);
         this.conflictResolverLog = cctx.logger(CacheVersionConflictResolverImpl.class);
+
+        mreg = cctx.grid().context().metric().registry("conflictResolver");
     }
 
     /** {@inheritDoc} */

--- a/modules/cdc-ext/src/main/java/org/apache/ignite/cdc/conflictresolve/CacheConflictResolutionManagerImpl.java
+++ b/modules/cdc-ext/src/main/java/org/apache/ignite/cdc/conflictresolve/CacheConflictResolutionManagerImpl.java
@@ -31,7 +31,7 @@ import org.apache.ignite.lang.IgniteFuture;
  * @see CacheVersionConflictResolver
  */
 public class CacheConflictResolutionManagerImpl<K, V> implements CacheConflictResolutionManager<K, V> {
-    /** */
+    /** Conflict resolver metrics registry name. */
     public static final String CONFLICT_RESOLVER_METRICS_REGISTRY_NAME = "conflict-resolver";
 
     /** Logger. */

--- a/modules/cdc-ext/src/main/java/org/apache/ignite/cdc/conflictresolve/CacheVersionConflictResolverImpl.java
+++ b/modules/cdc-ext/src/main/java/org/apache/ignite/cdc/conflictresolve/CacheVersionConflictResolverImpl.java
@@ -68,9 +68,6 @@ public class CacheVersionConflictResolverImpl implements CacheVersionConflictRes
     @GridToStringInclude
     protected final boolean conflictResolveFieldEnabled;
 
-    /** Conflict Resolver metric registry. */
-    private final MetricRegistryImpl mreg;
-
     /** Counter of new entry selected. */
     private final AtomicLongMetric newCnt;
 
@@ -78,21 +75,22 @@ public class CacheVersionConflictResolverImpl implements CacheVersionConflictRes
     private final AtomicLongMetric oldCnt;
 
     /** Count of the new version used name. */
-    public static final String NEW_EVENTS_CNT = "newSelectedCount";
+    public static final String ACCEPTED_EVENTS_CNT = "AcceptedCount";
 
     /** Count of the new version used description. */
-    public static final String NEW_EVENTS_CNT_DESC = "Count of new version used";
+    public static final String ACCEPTED_EVENTS_CNT_DESC = "Counter of accepted entries";
 
     /** Count of the old version used name. */
-    public static final String OLD_EVENTS_CNT = "oldSelectedCount";
+    public static final String REJECTED_EVENTS_CNT = "RejectedCount";
 
     /** Count of the old version used description. */
-    public static final String OLD_EVENTS_CNT_DESC = "Count of old version used";
+    public static final String REJECTED_EVENTS_CNT_DESC = "Counter of rejected entries";
 
     /**
      * @param clusterId Data center id.
      * @param conflictResolveField Field to resolve conflicts.
      * @param log Logger.
+     * @param mreg Metric registry.
      */
     public CacheVersionConflictResolverImpl(
         byte clusterId,
@@ -106,10 +104,8 @@ public class CacheVersionConflictResolverImpl implements CacheVersionConflictRes
 
         conflictResolveFieldEnabled = conflictResolveField != null;
 
-        this.mreg = mreg;
-
-        newCnt = mreg.longMetric(NEW_EVENTS_CNT, NEW_EVENTS_CNT_DESC);
-        oldCnt = mreg.longMetric(OLD_EVENTS_CNT, OLD_EVENTS_CNT_DESC);
+        newCnt = mreg.longMetric(ACCEPTED_EVENTS_CNT, ACCEPTED_EVENTS_CNT_DESC);
+        oldCnt = mreg.longMetric(REJECTED_EVENTS_CNT, REJECTED_EVENTS_CNT_DESC);
     }
 
     /** {@inheritDoc} */

--- a/modules/cdc-ext/src/main/java/org/apache/ignite/cdc/conflictresolve/CacheVersionConflictResolverImpl.java
+++ b/modules/cdc-ext/src/main/java/org/apache/ignite/cdc/conflictresolve/CacheVersionConflictResolverImpl.java
@@ -44,6 +44,18 @@ import org.apache.ignite.internal.util.typedef.internal.U;
  * </ul>
  */
 public class CacheVersionConflictResolverImpl implements CacheVersionConflictResolver {
+    /** Count of the new version used name. */
+    public static final String ACCEPTED_EVENTS_CNT = "AcceptedCount";
+
+    /** Count of the new version used description. */
+    public static final String ACCEPTED_EVENTS_CNT_DESC = "Count of accepted entries";
+
+    /** Count of the old version used name. */
+    public static final String REJECTED_EVENTS_CNT = "RejectedCount";
+
+    /** Count of the old version used description. */
+    public static final String REJECTED_EVENTS_CNT_DESC = "Count of rejected entries";
+
     /**
      * Cluster id.
      */
@@ -68,23 +80,11 @@ public class CacheVersionConflictResolverImpl implements CacheVersionConflictRes
     @GridToStringInclude
     protected final boolean conflictResolveFieldEnabled;
 
-    /** Counter of new entry selected. */
-    private final LongAdderMetric newCnt;
+    /** Count of the new version used. */
+    private final LongAdderMetric acceptedCnt;
 
-    /** Counter of old entry selected. */
-    private final LongAdderMetric oldCnt;
-
-    /** Count of the new version used name. */
-    public static final String ACCEPTED_EVENTS_CNT = "AcceptedCount";
-
-    /** Count of the new version used description. */
-    public static final String ACCEPTED_EVENTS_CNT_DESC = "Counter of accepted entries";
-
-    /** Count of the old version used name. */
-    public static final String REJECTED_EVENTS_CNT = "RejectedCount";
-
-    /** Count of the old version used description. */
-    public static final String REJECTED_EVENTS_CNT_DESC = "Counter of rejected entries";
+    /** Count of the old version used. */
+    private final LongAdderMetric rejectedCnt;
 
     /**
      * @param clusterId Data center id.
@@ -104,8 +104,8 @@ public class CacheVersionConflictResolverImpl implements CacheVersionConflictRes
 
         conflictResolveFieldEnabled = conflictResolveField != null;
 
-        newCnt = mreg.longAdderMetric(ACCEPTED_EVENTS_CNT, ACCEPTED_EVENTS_CNT_DESC);
-        oldCnt = mreg.longAdderMetric(REJECTED_EVENTS_CNT, REJECTED_EVENTS_CNT_DESC);
+        acceptedCnt = mreg.longAdderMetric(ACCEPTED_EVENTS_CNT, ACCEPTED_EVENTS_CNT_DESC);
+        rejectedCnt = mreg.longAdderMetric(REJECTED_EVENTS_CNT, REJECTED_EVENTS_CNT_DESC);
     }
 
     /** {@inheritDoc} */
@@ -121,11 +121,11 @@ public class CacheVersionConflictResolverImpl implements CacheVersionConflictRes
 
         if (useNew) {
             res.useNew();
-            newCnt.increment();
+            acceptedCnt.increment();
         }
         else {
             res.useOld();
-            oldCnt.increment();
+            rejectedCnt.increment();
         }
 
         return res;

--- a/modules/cdc-ext/src/main/java/org/apache/ignite/cdc/conflictresolve/CacheVersionConflictResolverImpl.java
+++ b/modules/cdc-ext/src/main/java/org/apache/ignite/cdc/conflictresolve/CacheVersionConflictResolverImpl.java
@@ -78,16 +78,16 @@ public class CacheVersionConflictResolverImpl implements CacheVersionConflictRes
     private final AtomicLongMetric oldCnt;
 
     /** Count of the new version used name. */
-    private final String NEW_EVENTS_CNT = "newSelectedCount";
+    public static final String NEW_EVENTS_CNT = "newSelectedCount";
 
     /** Count of the new version used description. */
-    private final String NEW_EVENTS_CNT_DESC = "Count of new version used";
+    public static final String NEW_EVENTS_CNT_DESC = "Count of new version used";
 
     /** Count of the old version used name. */
-    private final String OLD_EVENTS_CNT = "oldSelectedCount";
+    public static final String OLD_EVENTS_CNT = "oldSelectedCount";
 
     /** Count of the old version used description. */
-    private final String OLD_EVENTS_CNT_DESC = "Count of old version used";
+    public static final String OLD_EVENTS_CNT_DESC = "Count of old version used";
 
     /**
      * @param clusterId Data center id.

--- a/modules/cdc-ext/src/main/java/org/apache/ignite/cdc/conflictresolve/CacheVersionConflictResolverImpl.java
+++ b/modules/cdc-ext/src/main/java/org/apache/ignite/cdc/conflictresolve/CacheVersionConflictResolverImpl.java
@@ -44,16 +44,16 @@ import org.apache.ignite.internal.util.typedef.internal.U;
  * </ul>
  */
 public class CacheVersionConflictResolverImpl implements CacheVersionConflictResolver {
-    /** Count of the new version used name. */
+    /** Accepted entries count name. */
     public static final String ACCEPTED_EVENTS_CNT = "AcceptedCount";
 
-    /** Count of the new version used description. */
+    /** Accepted entries count description. */
     public static final String ACCEPTED_EVENTS_CNT_DESC = "Count of accepted entries";
 
-    /** Count of the old version used name. */
+    /** Rejected entries count name. */
     public static final String REJECTED_EVENTS_CNT = "RejectedCount";
 
-    /** Count of the old version used description. */
+    /** Rejected entries count description. */
     public static final String REJECTED_EVENTS_CNT_DESC = "Count of rejected entries";
 
     /**
@@ -80,10 +80,10 @@ public class CacheVersionConflictResolverImpl implements CacheVersionConflictRes
     @GridToStringInclude
     protected final boolean conflictResolveFieldEnabled;
 
-    /** Count of the new version used. */
+    /** Accepted entries count. */
     private final LongAdderMetric acceptedCnt;
 
-    /** Count of the old version used. */
+    /** Rejected entries count. */
     private final LongAdderMetric rejectedCnt;
 
     /**

--- a/modules/cdc-ext/src/main/java/org/apache/ignite/cdc/conflictresolve/CacheVersionConflictResolverImpl.java
+++ b/modules/cdc-ext/src/main/java/org/apache/ignite/cdc/conflictresolve/CacheVersionConflictResolverImpl.java
@@ -24,7 +24,7 @@ import org.apache.ignite.internal.processors.cache.version.CacheVersionConflictR
 import org.apache.ignite.internal.processors.cache.version.GridCacheVersionConflictContext;
 import org.apache.ignite.internal.processors.cache.version.GridCacheVersionedEntryEx;
 import org.apache.ignite.internal.processors.metric.MetricRegistryImpl;
-import org.apache.ignite.internal.processors.metric.impl.AtomicLongMetric;
+import org.apache.ignite.internal.processors.metric.impl.LongAdderMetric;
 import org.apache.ignite.internal.util.tostring.GridToStringInclude;
 import org.apache.ignite.internal.util.typedef.internal.S;
 import org.apache.ignite.internal.util.typedef.internal.U;
@@ -69,10 +69,10 @@ public class CacheVersionConflictResolverImpl implements CacheVersionConflictRes
     protected final boolean conflictResolveFieldEnabled;
 
     /** Counter of new entry selected. */
-    private final AtomicLongMetric newCnt;
+    private final LongAdderMetric newCnt;
 
     /** Counter of old entry selected. */
-    private final AtomicLongMetric oldCnt;
+    private final LongAdderMetric oldCnt;
 
     /** Count of the new version used name. */
     public static final String ACCEPTED_EVENTS_CNT = "AcceptedCount";
@@ -104,8 +104,8 @@ public class CacheVersionConflictResolverImpl implements CacheVersionConflictRes
 
         conflictResolveFieldEnabled = conflictResolveField != null;
 
-        newCnt = mreg.longMetric(ACCEPTED_EVENTS_CNT, ACCEPTED_EVENTS_CNT_DESC);
-        oldCnt = mreg.longMetric(REJECTED_EVENTS_CNT, REJECTED_EVENTS_CNT_DESC);
+        newCnt = mreg.longAdderMetric(ACCEPTED_EVENTS_CNT, ACCEPTED_EVENTS_CNT_DESC);
+        oldCnt = mreg.longAdderMetric(REJECTED_EVENTS_CNT, REJECTED_EVENTS_CNT_DESC);
     }
 
     /** {@inheritDoc} */
@@ -120,12 +120,12 @@ public class CacheVersionConflictResolverImpl implements CacheVersionConflictRes
         boolean useNew = isUseNew(ctx, oldEntry, newEntry);
 
         if (useNew) {
-            newCnt.increment();
             res.useNew();
+            newCnt.increment();
         }
         else {
-            oldCnt.increment();
             res.useOld();
+            oldCnt.increment();
         }
 
         return res;

--- a/modules/cdc-ext/src/main/java/org/apache/ignite/cdc/conflictresolve/DebugCacheVersionConflictResolverImpl.java
+++ b/modules/cdc-ext/src/main/java/org/apache/ignite/cdc/conflictresolve/DebugCacheVersionConflictResolverImpl.java
@@ -20,6 +20,7 @@ package org.apache.ignite.cdc.conflictresolve;
 import org.apache.ignite.IgniteLogger;
 import org.apache.ignite.internal.processors.cache.CacheObjectValueContext;
 import org.apache.ignite.internal.processors.cache.version.GridCacheVersionedEntryEx;
+import org.apache.ignite.internal.processors.metric.MetricRegistryImpl;
 import org.apache.ignite.internal.util.typedef.internal.S;
 
 /** Debug aware resolver. */
@@ -29,8 +30,13 @@ public class DebugCacheVersionConflictResolverImpl extends CacheVersionConflictR
      * @param conflictResolveField Field to resolve conflicts.
      * @param log Logger.
      */
-    public DebugCacheVersionConflictResolverImpl(byte clusterId, String conflictResolveField, IgniteLogger log) {
-        super(clusterId, conflictResolveField, log);
+    public DebugCacheVersionConflictResolverImpl(
+        byte clusterId,
+        String conflictResolveField,
+        IgniteLogger log,
+        MetricRegistryImpl mreg
+    ) {
+        super(clusterId, conflictResolveField, log, mreg);
     }
 
     /** {@inheritDoc} */

--- a/modules/cdc-ext/src/main/java/org/apache/ignite/cdc/conflictresolve/DebugCacheVersionConflictResolverImpl.java
+++ b/modules/cdc-ext/src/main/java/org/apache/ignite/cdc/conflictresolve/DebugCacheVersionConflictResolverImpl.java
@@ -29,6 +29,7 @@ public class DebugCacheVersionConflictResolverImpl extends CacheVersionConflictR
      * @param clusterId Data center id.
      * @param conflictResolveField Field to resolve conflicts.
      * @param log Logger.
+     * @param mreg Metric registry.
      */
     public DebugCacheVersionConflictResolverImpl(
         byte clusterId,

--- a/modules/cdc-ext/src/test/java/org/apache/ignite/cdc/CacheConflictOperationsTest.java
+++ b/modules/cdc-ext/src/test/java/org/apache/ignite/cdc/CacheConflictOperationsTest.java
@@ -81,6 +81,15 @@ public class CacheConflictOperationsTest extends GridCommonAbstractTest {
     }
 
     /** */
+    private static final byte FIRST_CLUSTER_ID = 1;
+
+    /** */
+    private static final byte SECOND_CLUSTER_ID = 2;
+
+    /** */
+    private static final byte THIRD_CLUSTER_ID = 3;
+
+    /** */
     private IgniteCache<String, ConflictResolvableTestData> cache;
 
     /** */
@@ -91,15 +100,6 @@ public class CacheConflictOperationsTest extends GridCommonAbstractTest {
 
     /** */
     private IgniteEx ign;
-
-    /** */
-    private static final byte FIRST_CLUSTER_ID = 1;
-
-    /** */
-    private static final byte SECOND_CLUSTER_ID = 2;
-
-    /** */
-    private static final byte THIRD_CLUSTER_ID = 3;
 
     /** {@inheritDoc} */
     @Override protected IgniteConfiguration getConfiguration(String igniteInstanceName) throws Exception {

--- a/modules/cdc-ext/src/test/java/org/apache/ignite/cdc/CacheConflictOperationsWithCustomResolverTest.java
+++ b/modules/cdc-ext/src/test/java/org/apache/ignite/cdc/CacheConflictOperationsWithCustomResolverTest.java
@@ -68,4 +68,9 @@ public class CacheConflictOperationsWithCustomResolverTest extends CacheConflict
             return res;
         }
     }
+
+    /** {@inheritDoc} */
+    @Override protected void checkMetrics(int newCnt, int oldCnt) {
+        // No op.
+    }
 }

--- a/modules/cdc-ext/src/test/java/org/apache/ignite/cdc/CacheConflictOperationsWithCustomResolverTest.java
+++ b/modules/cdc-ext/src/test/java/org/apache/ignite/cdc/CacheConflictOperationsWithCustomResolverTest.java
@@ -70,7 +70,7 @@ public class CacheConflictOperationsWithCustomResolverTest extends CacheConflict
     }
 
     /** {@inheritDoc} */
-    @Override protected void checkMetrics(int newCnt, int oldCnt) {
+    @Override protected void checkMetrics(int acceptedCnt, int rejectedCnt) {
         // No op.
     }
 }


### PR DESCRIPTION
### CDC metrics for conflict resolveer

There is no metrics for resolved entries during CDC, thus it's hard to analyse the number of accepted and rejected entries handled by conflict resolver. This commit fixes this issue.

**_What is new:_** 
- Metric registry added for `CacheConflictResolutionManagerImpl`, which allowed to register metrics at default `CacheVersionConflictResolverImpl`
- Metrics for resolved entries

_**Metrics:**_
| `AcceptedCount` | Count of accepted entries.
| `RejectedCount` | Count of rejected entries.