### PR TITLE
Upgrade spark-ext to spark 3.5

### DIFF
--- a/modules/spark-ext/pom.xml
+++ b/modules/spark-ext/pom.xml
@@ -36,7 +36,7 @@
     <properties>
         <scala.library.version>2.12.16</scala.library.version>
         <scala.test.version>3.2.12</scala.test.version>
-        <spark.version>3.2.2</spark.version>
+        <spark.version>3.5.3</spark.version>
         <spark.jackson.version>2.12.7</spark.jackson.version>
     </properties>
 

--- a/modules/spark-ext/spark/src/main/scala/org/apache/ignite/spark/impl/optimization/DateExpressions.scala
+++ b/modules/spark-ext/spark/src/main/scala/org/apache/ignite/spark/impl/optimization/DateExpressions.scala
@@ -52,8 +52,8 @@ private[optimization] object DateExpressions extends SupportedExpressions {
         case Month(date) ⇒
             checkChild(date)
 
-        case ParseToDate(left, format, child) ⇒
-            checkChild(left) && (format.isEmpty || checkChild(format.get)) && checkChild(child)
+        case ParseToDate(left, format, _, _) ⇒
+            checkChild(left) && (format.isEmpty || checkChild(format.get))
 
         case Quarter(date) ⇒
             checkChild(date)
@@ -101,7 +101,7 @@ private[optimization] object DateExpressions extends SupportedExpressions {
         case Month(date) ⇒
             Some(s"MINUTE(${childToString(date)})")
 
-        case ParseToDate(left, formatOption, _) ⇒
+        case ParseToDate(left, formatOption, _, _) ⇒
             formatOption match {
                 case Some(format) ⇒
                     Some(s"PARSEDATETIME(${childToString(left)}, ${childToString(format)})")

--- a/modules/spark-ext/spark/src/main/scala/org/apache/ignite/spark/impl/optimization/MathExpressions.scala
+++ b/modules/spark-ext/spark/src/main/scala/org/apache/ignite/spark/impl/optimization/MathExpressions.scala
@@ -106,7 +106,7 @@ private[optimization] object MathExpressions extends SupportedExpressions {
         case Rand(child, _) ⇒
             checkChild(child)
 
-        case Round(child, scale) ⇒
+        case Round(child, scale, _) ⇒
             checkChild(child) && checkChild(scale)
 
         case Signum(child) ⇒
@@ -230,7 +230,7 @@ private[optimization] object MathExpressions extends SupportedExpressions {
         case Rand(child, _) ⇒
             Some(s"RAND(${childToString(child)})")
 
-        case Round(child, scale) ⇒
+        case Round(child, scale, _) ⇒
             Some(s"ROUND(${childToString(child)}, ${childToString(scale)})")
 
         case Signum(child) ⇒

--- a/modules/spark-ext/spark/src/main/scala/org/apache/ignite/spark/impl/optimization/SystemExpressions.scala
+++ b/modules/spark-ext/spark/src/main/scala/org/apache/ignite/spark/impl/optimization/SystemExpressions.scala
@@ -18,7 +18,7 @@
 package org.apache.ignite.spark.impl.optimization
 
 import org.apache.ignite.IgniteException
-import org.apache.spark.sql.catalyst.expressions.{Coalesce, EqualTo, Expression, Greatest, If, IfNull, IsNotNull, IsNull, Least, Literal, NullIf, Nvl2}
+import org.apache.spark.sql.catalyst.expressions.{Coalesce, EqualTo, Expression, Greatest, If, IsNotNull, IsNull, Least, Literal, NullIf, Nvl2}
 
 /**
   * Object to support some built-in expressions like `nvl2` or `coalesce`.
@@ -31,9 +31,6 @@ private[optimization] object SystemExpressions extends SupportedExpressions {
 
         case Greatest(children) ⇒
             children.forall(checkChild)
-
-        case IfNull(left, right, _) ⇒
-            checkChild(left) && checkChild(right)
 
         case Least(children) ⇒
             children.forall(checkChild)
@@ -77,9 +74,6 @@ private[optimization] object SystemExpressions extends SupportedExpressions {
 
         case Greatest(children) ⇒
             Some(s"GREATEST(${children.map(childToString(_)).mkString(", ")})")
-
-        case IfNull(left, right, _) ⇒
-            Some(s"IFNULL(${childToString(left)}, ${childToString(right)})")
 
         case Least(children) ⇒
             Some(s"LEAST(${children.map(childToString(_)).mkString(", ")})")

--- a/modules/spark-ext/spark/src/main/scala/org/apache/ignite/spark/impl/package.scala
+++ b/modules/spark-ext/spark/src/main/scala/org/apache/ignite/spark/impl/package.scala
@@ -17,7 +17,6 @@
 
 package org.apache.ignite.spark
 
-import org.apache.commons.lang.StringUtils.equalsIgnoreCase
 import org.apache.ignite.cache.CacheMode
 import org.apache.ignite.cluster.ClusterNode
 import org.apache.ignite.configuration.CacheConfiguration
@@ -136,7 +135,7 @@ package object impl {
       * @return `True` if column is key.
       */
     def isKeyColumn(table: GridQueryTypeDescriptor, column: String): Boolean =
-        contains(allKeyFields(table), column) || equalsIgnoreCase(table.keyFieldName, column)
+        contains(allKeyFields(table), column) || column.equalsIgnoreCase(table.keyFieldName)
 
     /**
       * @param table Table.


### PR DESCRIPTION
Hi, I’d like to know if you’re open to updating spark-ext from Spark 3.2 to Spark 3.5.

Since I’m new to this repo and unfamiliar with the procedure, could you let me know the best way to approach it? This PR shows a preliminary version of the changes (it compiles but tests are not complete yet). Thanks!