### PR TITLE
IGNITE-28856 Fix ignite-extensions compilation after IGNITE-28727 and IGNITE-28819

### DIFF
--- a/modules/cdc-ext/src/test/java/org/apache/ignite/cdc/kafka/KafkaToIgniteMetadataUpdaterTest.java
+++ b/modules/cdc-ext/src/test/java/org/apache/ignite/cdc/kafka/KafkaToIgniteMetadataUpdaterTest.java
@@ -179,7 +179,7 @@ public class KafkaToIgniteMetadataUpdaterTest extends GridCommonAbstractTest {
             null,
             CU.affinityFields(null),
             BinaryConfiguration.DFLT_COMPACT_FOOTER,
-            CU::affinityFieldName,
+            BinaryUtils::affinityFieldName,
             log
         ) {
             @Override public boolean registerUserClassName(int typeId, String clsName, boolean failIfUnregistered,

--- a/modules/hibernate-ext/hibernate/src/main/java/org/apache/ignite/cache/hibernate/HibernateCacheProxy.java
+++ b/modules/hibernate-ext/hibernate/src/main/java/org/apache/ignite/cache/hibernate/HibernateCacheProxy.java
@@ -440,6 +440,32 @@ public class HibernateCacheProxy implements IgniteInternalCache<Object, Object> 
     }
 
     /** {@inheritDoc} */
+    @Override public boolean lockTxEntry(CacheEntry<Object, Object> entry, long waitTimeout) throws IgniteCheckedException {
+        return delegate.get().lockTxEntry(entry, waitTimeout);
+    }
+
+    /** {@inheritDoc} */
+    @Override public boolean lockTxEntries(
+        Collection<CacheEntry<Object, Object>> entries,
+        long waitTimeout
+    ) throws IgniteCheckedException {
+        return delegate.get().lockTxEntries(entries, waitTimeout);
+    }
+
+    /** {@inheritDoc} */
+    @Override public IgniteInternalFuture<Boolean> lockTxEntryAsync(CacheEntry<Object, Object> entry, long waitTimeout) {
+        return delegate.get().lockTxEntryAsync(entry, waitTimeout);
+    }
+
+    /** {@inheritDoc} */
+    @Override public IgniteInternalFuture<Boolean> lockTxEntriesAsync(
+        Collection<CacheEntry<Object, Object>> entries,
+        long waitTimeout
+    ) {
+        return delegate.get().lockTxEntriesAsync(entries, waitTimeout);
+    }
+
+    /** {@inheritDoc} */
     @Override public void unlock(Object key) throws IgniteCheckedException {
         delegate.get().unlock(keyTransformer.transform(key));
     }

--- a/modules/jms11-ext/src/main/java/org/apache/ignite/stream/jms11/JmsStreamer.java
+++ b/modules/jms11-ext/src/main/java/org/apache/ignite/stream/jms11/JmsStreamer.java
@@ -521,8 +521,8 @@ public class JmsStreamer<T extends Message, K, V> extends StreamAdapter<T, K, V>
             }
 
             executor.execute(new Runnable() {
-                @Override @SuppressWarnings("unchecked")
-                public void run() {
+                @SuppressWarnings("unchecked")
+                @Override public void run() {
                     processMessage((T)message);
                     if (batched) {
                         // batch completion may be handled by timer only

--- a/modules/spring-data-ext/spring-data/src/main/java/org/apache/ignite/springdata/repository/query/StringQuery.java
+++ b/modules/spring-data-ext/spring-data/src/main/java/org/apache/ignite/springdata/repository/query/StringQuery.java
@@ -135,8 +135,7 @@ class StringQuery implements DeclaredQuery {
 
     // See org.springframework.data.jpa.repository.query.DeclaredQuery#getAlias()
     /** {@inheritDoc} */
-    @Override @Nullable
-    public String getAlias() {
+    @Nullable @Override public String getAlias() {
         return alias;
     }
 


### PR DESCRIPTION
ignite-extensions master fails to compile against the current ignite 2.19.0-SNAPSHOT due to two recent core changes, plus checkstyle violations failing the CI:

1. IGNITE-28727 added four abstract methods to `IgniteInternalCache` (`lockTxEntry`, `lockTxEntries`, `lockTxEntryAsync`, `lockTxEntriesAsync`). `HibernateCacheProxy` (hibernate-ext) does not implement them.
2. IGNITE-28819 moved `CU.affinityFieldName` to `BinaryUtils`, breaking a method reference in `KafkaToIgniteMetadataUpdaterTest` (cdc-ext).
3. `JmsStreamer` (jms11-ext) and `StringQuery` (spring-data-ext) violate the `AnnotationOnSameLine` checkstyle rule (`@Override` not on the same line with its target).

Fix: delegating implementations of the four `lockTx*` methods in `HibernateCacheProxy` (same pattern as the neighboring lock/lockAll delegates); the test switched to `BinaryUtils::affinityFieldName`; annotations reordered to the common codestyle.

Verified: full reactor `clean test-compile` BUILD SUCCESS; full reactor `checkstyle:check -Pcheckstyle` — 0 violations in all 65 modules.

https://issues.apache.org/jira/browse/IGNITE-28856