### PR TITLE
IGNITE-28858 Reduce CDC replication tests execution time

### DIFF
--- a/modules/cdc-ext/src/test/java/org/apache/ignite/cdc/AbstractReplicationTest.java
+++ b/modules/cdc-ext/src/test/java/org/apache/ignite/cdc/AbstractReplicationTest.java
@@ -210,7 +210,7 @@ public abstract class AbstractReplicationTest extends GridCommonAbstractTest {
                     .setCdcEnabled(true)));
 
             cfg.getDataStorageConfiguration()
-                .setWalForceArchiveTimeout(5_000);
+                .setWalForceArchiveTimeout(1_000);
 
             cfg.setConsistentId(igniteInstanceName);
         }
@@ -529,7 +529,7 @@ public abstract class AbstractReplicationTest extends GridCommonAbstractTest {
     /** Test that destination cluster applies expiration policy on received entries. */
     @Test
     public void testWithExpiryPolicy() throws Exception {
-        Factory<? extends ExpiryPolicy> factory = () -> new CreatedExpiryPolicy(new Duration(TimeUnit.SECONDS, 30));
+        Factory<? extends ExpiryPolicy> factory = () -> new CreatedExpiryPolicy(new Duration(TimeUnit.SECONDS, 10));
 
         IgniteCache<Integer, ConflictResolvableTestData> srcCache = createCache(srcCluster[0], ACTIVE_PASSIVE_CACHE, factory);
         IgniteCache<Integer, ConflictResolvableTestData> destCache = createCache(destCluster[0], ACTIVE_PASSIVE_CACHE, factory);

--- a/modules/cdc-ext/src/test/java/org/apache/ignite/cdc/postgresql/CdcPostgreSqlReplicationTest.java
+++ b/modules/cdc-ext/src/test/java/org/apache/ignite/cdc/postgresql/CdcPostgreSqlReplicationTest.java
@@ -103,7 +103,7 @@ public class CdcPostgreSqlReplicationTest extends CdcPostgreSqlReplicationAbstra
             .setCdcEnabled(true);
 
         DataStorageConfiguration dataStorageConfiguration = new DataStorageConfiguration()
-            .setWalForceArchiveTimeout(5_000)
+            .setWalForceArchiveTimeout(1_000)
             .setDefaultDataRegionConfiguration(dataRegionConfiguration);
 
         cfg.setDataStorageConfiguration(dataStorageConfiguration);

--- a/modules/cdc-ext/src/test/java/org/apache/ignite/cdc/postgresql/JavaToSqlTypeMapperTest.java
+++ b/modules/cdc-ext/src/test/java/org/apache/ignite/cdc/postgresql/JavaToSqlTypeMapperTest.java
@@ -92,7 +92,7 @@ public class JavaToSqlTypeMapperTest extends CdcPostgreSqlReplicationAbstractTes
             .setCdcEnabled(true);
 
         DataStorageConfiguration dataStorageConfiguration = new DataStorageConfiguration()
-            .setWalForceArchiveTimeout(5_000)
+            .setWalForceArchiveTimeout(1_000)
             .setDefaultDataRegionConfiguration(dataRegionConfiguration);
 
         cfg.setDataStorageConfiguration(dataStorageConfiguration);


### PR DESCRIPTION
Two cheap timing changes cut the CDC replication tests' execution time roughly in half (measured locally, JDK 17):

1. **`walForceArchiveTimeout`: 5000 → 1000 ms** (`AbstractReplicationTest` + PostgreSQL tests). CDC consumes only archived WAL segments, so every replication wait in a test pays up to a 5 s segment-archive latency, several times per test. With 1 s the `testActivePassiveReplication*` subset went from 124.7 s to 78.3 s (−37%).

2. **`testWithExpiryPolicy` TTL: 30 → 10 s**. The test waits for a real TTL expiration twice (source, then destination). With TTL 10 s the method went from 31.9 s to ~11.7 s per run (−63%); verified green on the full 12-combination matrix (139.3 s total). 10 s still leaves an order-of-magnitude margin over the observed replication lag.

Expected effect on CI: ~25–30 min less CPU across the Cdc suite; together with the class split from IGNITE-28857 the slowest Parallel Tests batch drops from ~10 to ~7 min.

Independent of #358 (no overlapping lines), either merge order works.

https://issues.apache.org/jira/browse/IGNITE-28858

🤖 Generated with [Claude Code](https://claude.com/claude-code)